### PR TITLE
Add printing of timestamps pre and post build, test, and push steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
               "${UPDATE_DIR}"
               docker tag "${GAME_IMAGE}" "${REPOSITORY}:${GAME_VERSION}-layered"
           fi
+          date
           docker images
           docker inspect "${GAME_IMAGE}"
           docker history "${GAME_IMAGE}"
@@ -93,6 +94,7 @@ jobs:
                   --rm \
                   "${GAME_IMAGE}" \
                   "printenv && echo && ls -al && echo && exec ${GAME_BIN} -game ${GAME} +version +exit"
+              echo; date
           fi
           # Push the game image
           if [ ! "${NO_PUSH}" = 'true' ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,14 @@ jobs:
             GAME_BIN="srcds_linux"
           fi
           echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin
-          date
           # Build / Update the game image
           if [ "${PIPELINE}" = 'build' ]; then
               GAME_IMAGE="${REPOSITORY}:${GAME_VERSION}"
               if [ "${CACHE}" = 'true' ]; then
+                  date
                   time docker pull "${GAME_IMAGE}" || true
               fi
+              date
               time docker build \
                   --cache-from "${GAME_IMAGE}" \
                   --build-arg APPID="${APPID}" \
@@ -71,6 +72,7 @@ jobs:
               if [ "${LATEST}" = 'true' ]; then
                   docker tag "${GAME_IMAGE}" "${REPOSITORY}:latest"
               fi
+              date
           elif [ "${PIPELINE}" = 'update' ]; then
               GAME_IMAGE="${REPOSITORY}:latest"
               time docker pull "${GAME_IMAGE}"
@@ -81,8 +83,8 @@ jobs:
               --label "game_update_count=${GAME_UPDATE_COUNT}" \
               "${UPDATE_DIR}"
               docker tag "${GAME_IMAGE}" "${REPOSITORY}:${GAME_VERSION}-layered"
+              date
           fi
-          date
           docker images
           docker inspect "${GAME_IMAGE}"
           docker history "${GAME_IMAGE}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,9 @@ jobs:
               date
           elif [ "${PIPELINE}" = 'update' ]; then
               GAME_IMAGE="${REPOSITORY}:latest"
+              date
               time docker pull "${GAME_IMAGE}"
+              date
               time docker build \
               --build-arg GAME_IMAGE="${GAME_IMAGE}" \
               -t "${GAME_IMAGE}" \

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,9 @@ script:
       date
   elif [ "${PIPELINE}" = 'update' ]; then
       GAME_IMAGE="${REPOSITORY}:latest"
+      date
       travis_wait 40 time docker pull "${GAME_IMAGE}"
+      date
       travis_wait 40 time docker build \
       --build-arg GAME_IMAGE="${GAME_IMAGE}" \
       -t "${GAME_IMAGE}" \

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,14 @@ before_script:
   echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin
 script:
 - |
-  date
   # Build / Update the game image
   if [ "${PIPELINE}" = 'build' ]; then
       GAME_IMAGE="${REPOSITORY}:${GAME_VERSION}"
       if [ "${CACHE}" = 'true' ]; then
+          date
           time docker pull "${GAME_IMAGE}" || true
       fi
+      date
       travis_wait 40 time docker build \
           --cache-from "${GAME_IMAGE}" \
           --build-arg APPID="${APPID}" \
@@ -62,6 +63,7 @@ script:
       if [ "${LATEST}" = 'true' ]; then
           docker tag "${GAME_IMAGE}" "${REPOSITORY}:latest"
       fi
+      date
   elif [ "${PIPELINE}" = 'update' ]; then
       GAME_IMAGE="${REPOSITORY}:latest"
       travis_wait 40 time docker pull "${GAME_IMAGE}"
@@ -72,8 +74,8 @@ script:
       --label "game_update_count=${GAME_UPDATE_COUNT}" \
       "${UPDATE_DIR}"
       docker tag "${GAME_IMAGE}" "${REPOSITORY}:${GAME_VERSION}-layered"
+      date
   fi
-  date
   docker images
   docker inspect "${GAME_IMAGE}"
   docker history "${GAME_IMAGE}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ script:
       "${UPDATE_DIR}"
       docker tag "${GAME_IMAGE}" "${REPOSITORY}:${GAME_VERSION}-layered"
   fi
+  date
   docker images
   docker inspect "${GAME_IMAGE}"
   docker history "${GAME_IMAGE}"
@@ -85,6 +86,7 @@ script:
           --rm \
           "${GAME_IMAGE}" \
           "printenv && echo && ls -al && echo && exec ${GAME_BIN} -game ${GAME} +version +exit"
+      echo; date
   fi
 - |
   # Push the game image

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,13 +50,14 @@ jobs:
     displayName: Before Script
   - script: |
       set -e
-      date
       # Build / Update the game image
       if [ "${PIPELINE}" = 'build' ]; then
           GAME_IMAGE="${REPOSITORY}:${GAME_VERSION}"
           if [ "${CACHE}" = 'true' ]; then
+              date
               docker pull "${GAME_IMAGE}" || true
           fi
+          date
           docker build \
               --cache-from "${GAME_IMAGE}" \
               --build-arg APPID="${APPID}" \
@@ -75,6 +76,7 @@ jobs:
           if [ "${LATEST}" = 'true' ]; then
               docker tag "${GAME_IMAGE}" "${REPOSITORY}:latest"
           fi
+          date
       elif [ "${PIPELINE}" = 'update' ]; then
           GAME_IMAGE="${REPOSITORY}:latest"
           docker pull "${GAME_IMAGE}"
@@ -85,8 +87,8 @@ jobs:
           --label "game_update_count=${GAME_UPDATE_COUNT}" \
           "${UPDATE_DIR}"
           docker tag "${GAME_IMAGE}" "${REPOSITORY}:${GAME_VERSION}-layered"
+          date
       fi
-      date
       echo; docker images
       echo; docker inspect "${GAME_IMAGE}"
       echo; docker history "${GAME_IMAGE}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,9 @@ jobs:
           date
       elif [ "${PIPELINE}" = 'update' ]; then
           GAME_IMAGE="${REPOSITORY}:latest"
+          date
           time docker pull "${GAME_IMAGE}"
+          date
           time docker build \
           --build-arg GAME_IMAGE="${GAME_IMAGE}" \
           -t "${GAME_IMAGE}" \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,10 +55,10 @@ jobs:
           GAME_IMAGE="${REPOSITORY}:${GAME_VERSION}"
           if [ "${CACHE}" = 'true' ]; then
               date
-              docker pull "${GAME_IMAGE}" || true
+              time docker pull "${GAME_IMAGE}" || true
           fi
           date
-          docker build \
+          time docker build \
               --cache-from "${GAME_IMAGE}" \
               --build-arg APPID="${APPID}" \
               --build-arg MOD="${MOD}" \
@@ -79,8 +79,8 @@ jobs:
           date
       elif [ "${PIPELINE}" = 'update' ]; then
           GAME_IMAGE="${REPOSITORY}:latest"
-          docker pull "${GAME_IMAGE}"
-          docker build \
+          time docker pull "${GAME_IMAGE}"
+          time docker build \
           --build-arg GAME_IMAGE="${GAME_IMAGE}" \
           -t "${GAME_IMAGE}" \
           --label "game_version=${GAME_VERSION}" \
@@ -101,7 +101,7 @@ jobs:
       # Test the game image
       if [ ! "${NO_TEST}" = 'true' ]; then
           date
-          docker run \
+          time docker run \
               -t \
               --rm \
               "${GAME_IMAGE}" \
@@ -114,7 +114,7 @@ jobs:
       # Push the game image
       if [ ! "${NO_PUSH}" = 'true' ]; then
           date
-          docker push "${REPOSITORY}"
+          time docker push "${REPOSITORY}"
           date
       fi
     displayName: Push Game Image


### PR DESCRIPTION
This change standardizes printing of timestamps before and after build, test, and push steps for improved traceability.