### PR TITLE
Update readme travis badges links to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 |:-:|:-:|
 | [![pipeline-travis-build-badge][]][pipeline-travis-build-link] [![pipeline-azurepipelines-build-badge][]][pipeline-azurepipelines-build-link] [![pipeline-circleci-build-badge][]][pipeline-circleci-build-link] | [![pipeline-travis-update-badge][]][pipeline-travis-update-link] [![pipeline-azurepipelines-update-badge][]][pipeline-azurepipelines-update-link] [![pipeline-circleci-update-badge][]][pipeline-circleci-update-link] |
 
-[pipeline-travis-build-badge]: https://img.shields.io/travis/startersclan/docker-sourceservers/build.svg?label=&logo=travis&style=flat-square
-[pipeline-travis-build-link]: https://travis-ci.org/startersclan/docker-sourceservers/builds
-[pipeline-travis-update-badge]: https://img.shields.io/travis/startersclan/docker-sourceservers/update.svg?label=&logo=travis&style=flat-square
-[pipeline-travis-update-link]: https://travis-ci.org/startersclan/docker-sourceservers/builds
+[pipeline-travis-build-badge]: https://img.shields.io/travis/com/startersclan/docker-sourceservers/build.svg?label=&logo=travis&style=flat-square
+[pipeline-travis-build-link]: https://travis-ci.com/startersclan/docker-sourceservers/builds
+[pipeline-travis-update-badge]: https://img.shields.io/travis/com/startersclan/docker-sourceservers/update.svg?label=&logo=travis&style=flat-square
+[pipeline-travis-update-link]: https://travis-ci.com/startersclan/docker-sourceservers/builds
 
 [pipeline-azurepipelines-build-badge]: https://img.shields.io/azure-devops/build/startersclan/docker-sourceservers/2/build.svg?label=&logo=azure-pipelines&style=flat-square
 [pipeline-azurepipelines-build-link]: https://dev.azure.com/startersclan/docker-sourceservers/_build?definitionId=2


### PR DESCRIPTION
Travis badges will point to build history on `travis-ci.com` instead of `travis-ci.org`.

Addresses #9 
