### PR TITLE
Fix (workaround): Implement workaround for +force_install_dir failing for build pipeline

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,6 +10,9 @@ ARG FIX_APPMANIFEST=false
 ARG CLIENT_APPID
 ARG INSTALL_COUNT=3
 
+# Workaround for +force_install_dir not working properly: https://github.com/ValveSoftware/steam-for-linux/issues/7843#issuecomment-856894946
+RUN mkdir -p "$SERVER_DIR/steamapps"
+
 # Download game
 RUN echo "[BUILD] SERVER_DIR: $SERVER_DIR"; \
     echo "[BUILD] APPMANIFEST_AR_URL: $APPMANIFEST_AR_URL"; \


### PR DESCRIPTION
Closes #17

This implements a workaround for a bug in a recent steamcmd update that has cuased +force_install_dir to not be working properly. See: https://github.com/ValveSoftware/steam-for-linux/issues/7843#issuecomment-856894946