### PR TITLE
Docs: Add docker-compose.yml example and use binary as entrypoint in readme `docker run` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ The following are some guidelines on how to use the provided images with `docker
 
 #### ENTRYPOINT and CMD
 
-Currently, the default `ENTRYPOINT` for all game images is [`"bash", "-c"`](build/Dockerfile#L72), and the `CMD` is [`""`](build/Dockerfile#L73). These values make it convenient especially in development environments where the game's command line can simply be appended as the final argument to the `docker run` command for starting a server.
+Currently, the default `ENTRYPOINT` for all game images is [`"bash", "-c"`](build/Dockerfile#L72), and the `CMD` is [`""`](build/Dockerfile#L73). These values make it convenient especially in development environments where the game's command line can simply be appended as the final argument to the `docker run` command for starting a server. However, supplying a shell script containing nested quotes as the `CMD` might be error prone.
+
+Hence, the recommended way is to supply the server binary as the `ENTRYPOINT`, and append any arguments as the `CMD` see an example [here](#starting).
 
 Each of the default values can also be overridden at runtime, a feature well supported by container orchestration tools such as [Kubernetes](https://kubernetes.io/docs/home/) and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/), and the standalone tool, [Docker Compose](https://docs.docker.com/compose/). Alternatively, they can be modified as part of the build steps in custom images.
 
@@ -204,15 +206,21 @@ The following are some examples of how the game servers can be started:
 
 ```shell
 # Counter-Strike: Global Offensive
-docker run -it -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+docker run -it -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
 
 # Counter-Strike 1.6
-docker run -it -p 27016:27016/udp goldsourceservers/cstrike:latest 'hlds_linux -game cstrike +port 27016 +maxplayers 10 +map de_dust2'
+docker run -it -p 27016:27016/udp --entrypoint hlds_linux goldsourceservers/cstrike:latest -game cstrike +port 27016 +maxplayers 10 +map de_dust2
 ```
 
 * `-t` for a pseudo-TTY is mandatory; servers may not run correctly without it
 * `-i` for STDIN for interactive use of the game console
 * `-d` for running the container in detached mode
+
+Alternatively, you may use a [`docker-compose.yml`](docker-compose.yml):
+
+```shell
+docker-compose up -d
+```
 
 #### Attaching
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2.2'
+services:
+  # srcds
+  csgo:
+    image: sourceservers/csgo:latest
+    ports:
+      - 27015:27015
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - srcds_linux
+    command:
+      - -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+  # hlds
+  cstrike:
+    image: goldsourceservers/cstrike:latest
+    ports:
+      - 27016:27016
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - hlds_linux
+    command:
+      - -game cstrike +port 27016 +maxplayers 10 +map de_dust2


### PR DESCRIPTION
Adds example documentation, so that newer users know the best practices of how to run servers using `docker run` or `docker-compose`.

By using the server binary as the entrypoint, there is no more reliance on the image's in-built `ENTRYPOINT [ "bin/bash", "-c" ]` as a convenience feature that makes `CMD`'s first argument PID 1. 

```sh
$ docker-compose up
Creating network "docker-sourceservers_default" with the default driver
Creating docker-sourceservers_csgo_1 ... 
Creating docker-sourceservers_cstrike_1 ... 

$ docker attach docker-sourceservers_csgo_1 
MasterRequestRestart
Your server needs to be restarted in order to receive the latest update.
status
hostname: Counter-Strike: Global Offensive
version : 1.37.7.0/13770 1185/8012 secure  [A:1:1434222592:18370] 
udp/ip  : 192.168.176.3:27015  (public ip: 112.199.150.125)
os      :  Linux
type    :  community dedicated
map     : de_dust2
players : 0 humans, 0 bots (10/0 max) (hibernating)

# userid name uniqueid connected ping loss state rate adr

$ docker attach docker-sourceservers_cstrike_1 
status
hostname:  Counter-Strike 1.6 Server
version :  48/1.1.2.7/Stdio 7882 secure  (10)
tcp/ip  :  192.168.176.2:27016
map     :  de_dust2 at: 0 x, 0 y, 0 z
players :  0 active (10 max)

#      name userid uniqueid frag time ping loss adr
0 users
exit
```

Related: #1, #3, #22

@joeltimothyoh 