### PR TITLE
Docs: Revise 'Running' and 'Updating' sections in README.md and add docker-compose.yml samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The following are some guidelines on how to use the provided images with `docker
 
 #### ENTRYPOINT and CMD
 
-Currently, the default `ENTRYPOINT` for all game images is [`"bash", "-c"`](build/Dockerfile#L72), and the `CMD` is [`""`](build/Dockerfile#L73). These values make it convenient especially in development environments where the game's command line can simply be appended as the final argument to the `docker run` command for starting a server. The default entrypoint also allows a string of runtime initialization commands to be executed at runtime, similar to what's typically achieved using entrypoint scripts such as `docker-entrypoint.yml`.
+Currently, the default `ENTRYPOINT` for all game images is [`"bash", "-c"`](build/Dockerfile#L72), and the `CMD` is [`""`](build/Dockerfile#L73). These values make it convenient especially in development environments where the game's command line can simply be appended as the final argument to the `docker run` command for starting a server. The default entrypoint also allows a string of runtime initialization commands to be executed at runtime, similar to what's typically achieved using entrypoint scripts such as `docker-entrypoint.sh`.
 
 In environments or container orchestrators where it is possible to use init containers for provisioning containers with their necessary configuration before application startup, the recommended approach would be to set the game binary as the container's `ENTRYPOINT` and its arguments as the container's `CMD`, as is documented [here](#starting).
 

--- a/README.md
+++ b/README.md
@@ -260,12 +260,6 @@ docker exec containername bash -c 'printenv && ls -al && ps aux'     # Multiple 
 
 To update a gameserver, simply initiate a pull for the game image by the `latest` tag and restart the server.
 
-```sh
-docker pull sourceservers/csgo:latest
-docker rm -f srcds-csgo
-docker run --name srcds-csgo -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
-```
-
 There are many ways to detect when a gameserver needs an update but that is out of the scope of the project. Here is a simple [example](https://stackoverflow.com/a/44740429/3891117) for utilizing a `cronjob` for updating a container.
 
 ## Important Considerations

--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest '
 docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
 ## Via custom entrypoint (game binary srcds_linux)
 docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
-## Via custom entrypoint (e.g. /bin/sh)
-docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint /bin/sh sourceservers/csgo:latest -c 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+## Via custom, explicit entrypoint (/bin/bash)
+docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint /bin/bash sourceservers/csgo:latest -c 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
 
 # Counter-Strike 1.6
 ## Via default entrypoint (/bin/bash -c)
@@ -220,8 +220,8 @@ docker run -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'hlds_linux -
 docker run -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
 ## Via custom entrypoint (game binary hlds_linux)
 docker run -it -p 28015:28015/udp --entrypoint hlds_linux goldsourceservers/cstrike:latest -game cstrike +port 28015 +maxplayers 10 +map de_dust2
-## Via custom entrypoint (e.g. /bin/sh)
-docker run -it -p 28015:28015/udp --entrypoint /bin/sh goldsourceservers/cstrike:latest -c 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
+## Via custom, explicit entrypoint (/bin/bash)
+docker run -it -p 28015:28015/udp --entrypoint /bin/bash goldsourceservers/cstrike:latest -c 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
 ```
 
 * `-t` for a pseudo-TTY is mandatory; servers may not run correctly without it

--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ The following are some guidelines on how to use the provided images with `docker
 
 #### ENTRYPOINT and CMD
 
-Currently, the default `ENTRYPOINT` for all game images is [`"bash", "-c"`](build/Dockerfile#L72), and the `CMD` is [`""`](build/Dockerfile#L73). These values make it convenient especially in development environments where the game's command line can simply be appended as the final argument to the `docker run` command for starting a server. However, supplying a shell script containing nested quotes as the `CMD` might be error prone.
+Currently, the default `ENTRYPOINT` for all game images is [`"bash", "-c"`](build/Dockerfile#L72), and the `CMD` is [`""`](build/Dockerfile#L73). These values make it convenient especially in development environments where the game's command line can simply be appended as the final argument to the `docker run` command for starting a server. The default entrypoint also allows a string of runtime initialization commands to be executed at runtime, similar to what's typically achieved using entrypoint scripts such as `docker-entrypoint.yml`.
 
-Hence, the recommended way is to supply the server binary as the `ENTRYPOINT`, and append any arguments as the `CMD` see an example [here](#starting).
+In environments or container orchestrators where it is possible to use init containers for provisioning containers with their necessary configuration before application startup, the recommended approach would be to set the game binary as the container's `ENTRYPOINT` and its arguments as the container's `CMD`, as is documented [here](#starting).
 
 Each of the default values can also be overridden at runtime, a feature well supported by container orchestration tools such as [Kubernetes](https://kubernetes.io/docs/home/) and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/), and the standalone tool, [Docker Compose](https://docs.docker.com/compose/). Alternatively, they can be modified as part of the build steps in custom images.
 
@@ -206,19 +206,32 @@ The following are some examples of how the game servers can be started:
 
 ```shell
 # Counter-Strike: Global Offensive
-docker run -it -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+## Via default entrypoint (/bin/bash -c)
+docker run --rm -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+docker run --rm -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+## Via custom entrypoint (game binary srcds_linux)
+docker run --rm -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+## Via custom entrypoint (e.g. /bin/sh)
+docker run --rm -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint /bin/sh sourceservers/csgo:latest -c 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
 
 # Counter-Strike 1.6
-docker run -it -p 27016:27016/udp --entrypoint hlds_linux goldsourceservers/cstrike:latest -game cstrike +port 27016 +maxplayers 10 +map de_dust2
+## Via default entrypoint (/bin/bash -c)
+docker run --rm -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
+docker run --rm -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
+## Via custom entrypoint (game binary hlds_linux)
+docker run --rm -it -p 28015:28015/udp --entrypoint hlds_linux goldsourceservers/cstrike:latest -game cstrike +port 28015 +maxplayers 10 +map de_dust2
+## Via custom entrypoint (e.g. /bin/sh)
+docker run --rm -it -p 28015:28015/udp --entrypoint /bin/sh goldsourceservers/cstrike:latest -c 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
 ```
 
 * `-t` for a pseudo-TTY is mandatory; servers may not run correctly without it
 * `-i` for STDIN for interactive use of the game console
 * `-d` for running the container in detached mode
 
-Alternatively, you may use a [`docker-compose.yml`](docker-compose.yml):
+For a more declarative approach, opt to use container manifests such as [`docker-compose.yml`](docker-compose.yml):
 
 ```shell
+# Via docker-compose in detached mode
 docker-compose up -d
 ```
 
@@ -249,8 +262,8 @@ To update a gameserver, simply initiate a pull for the game image by the `latest
 
 ```sh
 docker pull sourceservers/csgo:latest
-docker rm -f csgo-server
-docker run --name csgo-server -it -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+docker rm -f srcds-csgo
+docker run --name srcds-csgo -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
 ```
 
 There are many ways to detect when a gameserver needs an update but that is out of the scope of the project. Here is a simple [example](https://stackoverflow.com/a/44740429/3891117) for utilizing a `cronjob` for updating a container.

--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ docker run -it -p 28015:28015/udp --entrypoint /bin/bash goldsourceservers/cstri
 * `-i` for STDIN for interactive use of the game console
 * `-d` for running the container in detached mode
 
-For a more declarative approach, opt to use container manifests such as [`docker-compose.yml`](docs/samples/docker-compose):
+For a more declarative approach, define game server environments within container manifests such as [`docker-compose.yml`](docs/samples/docker-compose) which can be used for managing instances:
 
 ```shell
-# Via docker-compose in detached mode
-docker-compose up -d
+# Via docker-compose
+docker-compose up
 ```
 
 #### Attaching

--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ The following are some guidelines on how to use the provided images with `docker
 
 #### ENTRYPOINT and CMD
 
-Currently, the default `ENTRYPOINT` for all game images is [`"bash", "-c"`](build/Dockerfile#L72), and the `CMD` is [`""`](build/Dockerfile#L73). These values make it convenient especially in development environments where the game's command line can simply be appended as the final argument to the `docker run` command for starting a server.
+Currently, the default `ENTRYPOINT` for all game images is [`"bash", "-c"`](build/Dockerfile#L72), and the `CMD` is [`""`](build/Dockerfile#L73). These values make it convenient especially in development environments where the game's command line can simply be appended as the final argument to the `docker run` command for starting a server. However, supplying a shell script containing nested quotes as the `CMD` might be error prone.
+
+Hence, the recommended way is to supply the server binary as the `ENTRYPOINT`, and append any arguments as the `CMD` see an example [here](#starting).
 
 Each of the default values can also be overridden at runtime, a feature well supported by container orchestration tools such as [Kubernetes](https://kubernetes.io/docs/home/) and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/), and the standalone tool, [Docker Compose](https://docs.docker.com/compose/). Alternatively, they can be modified as part of the build steps in custom images.
 
@@ -204,15 +206,21 @@ The following are some examples of how the game servers can be started:
 
 ```shell
 # Counter-Strike: Global Offensive
-docker run -it -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+docker run -it -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
 
 # Counter-Strike 1.6
-docker run -it -p 27016:27016/udp goldsourceservers/cstrike:latest 'hlds_linux -game cstrike +port 27016 +maxplayers 10 +map de_dust2'
+docker run -it -p 27016:27016/udp --entrypoint hlds_linux goldsourceservers/cstrike:latest -game cstrike +port 27016 +maxplayers 10 +map de_dust2
 ```
 
 * `-t` for a pseudo-TTY is mandatory; servers may not run correctly without it
 * `-i` for STDIN for interactive use of the game console
 * `-d` for running the container in detached mode
+
+Alternatively, you may use a [`docker-compose.yml`](docker-compose.yml):
+
+```shell
+docker-compose up -d
+```
 
 #### Attaching
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ docker run -it -p 28015:28015/udp --entrypoint /bin/sh goldsourceservers/cstrike
 * `-i` for STDIN for interactive use of the game console
 * `-d` for running the container in detached mode
 
-For a more declarative approach, opt to use container manifests such as [`docker-compose.yml`](docker-compose.yml):
+For a more declarative approach, opt to use container manifests such as [`docker-compose.yml`](docs/samples/docker-compose):
 
 ```shell
 # Via docker-compose in detached mode

--- a/README.md
+++ b/README.md
@@ -209,18 +209,18 @@ The following are some examples of how the game servers can be started:
 ## Via default entrypoint (/bin/bash -c)
 docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
 docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
-## Via custom entrypoint (game binary srcds_linux)
+## Via custom entrypoint (game binary)
 docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
-## Via custom, explicit entrypoint (/bin/bash)
+## Via custom entrypoint (/bin/bash)
 docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint /bin/bash sourceservers/csgo:latest -c 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
 
 # Counter-Strike 1.6
 ## Via default entrypoint (/bin/bash -c)
 docker run -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
 docker run -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
-## Via custom entrypoint (game binary hlds_linux)
+## Via custom entrypoint (game binary)
 docker run -it -p 28015:28015/udp --entrypoint hlds_linux goldsourceservers/cstrike:latest -game cstrike +port 28015 +maxplayers 10 +map de_dust2
-## Via custom, explicit entrypoint (/bin/bash)
+## Via custom entrypoint (/bin/bash)
 docker run -it -p 28015:28015/udp --entrypoint /bin/bash goldsourceservers/cstrike:latest -c 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,21 +207,21 @@ The following are some examples of how the game servers can be started:
 ```shell
 # Counter-Strike: Global Offensive
 ## Via default entrypoint (/bin/bash -c)
-docker run --rm -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
-docker run --rm -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
 ## Via custom entrypoint (game binary srcds_linux)
-docker run --rm -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
 ## Via custom entrypoint (e.g. /bin/sh)
-docker run --rm -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint /bin/sh sourceservers/csgo:latest -c 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint /bin/sh sourceservers/csgo:latest -c 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
 
 # Counter-Strike 1.6
 ## Via default entrypoint (/bin/bash -c)
-docker run --rm -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
-docker run --rm -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
+docker run -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
+docker run -it -p 28015:28015/udp goldsourceservers/cstrike:latest 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
 ## Via custom entrypoint (game binary hlds_linux)
-docker run --rm -it -p 28015:28015/udp --entrypoint hlds_linux goldsourceservers/cstrike:latest -game cstrike +port 28015 +maxplayers 10 +map de_dust2
+docker run -it -p 28015:28015/udp --entrypoint hlds_linux goldsourceservers/cstrike:latest -game cstrike +port 28015 +maxplayers 10 +map de_dust2
 ## Via custom entrypoint (e.g. /bin/sh)
-docker run --rm -it -p 28015:28015/udp --entrypoint /bin/sh goldsourceservers/cstrike:latest -c 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
+docker run -it -p 28015:28015/udp --entrypoint /bin/sh goldsourceservers/cstrike:latest -c 'printenv && ls -al && exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2'
 ```
 
 * `-t` for a pseudo-TTY is mandatory; servers may not run correctly without it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2.2'
+services:
+  # srcds
+  csgo:
+    image: sourceservers/csgo:latest
+    ports:
+      - 27015:27015
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - srcds_linux
+    command:
+      - -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+  # hlds
+  cstrike:
+    image: goldsourceservers/cstrike:latest
+    ports:
+      - 27016:27016
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - hlds_linux
+    command:
+      - -game cstrike +port 27016 +maxplayers 10 +map de_dust2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2.2'
 services:
-  srcds-csgo:
+  srcds-csgo-1:
     image: sourceservers/csgo:latest
     ports:
       - 27015:27015/tcp
@@ -8,9 +8,24 @@ services:
     stdin_open: true
     tty: true
     entrypoint:
+      - /bin/bash
+      - -c
+    command:
+      - | 
+        printenv
+        ls -al
+        srcds_linux -game csgo -port 27016 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+  srcds-csgo-2:
+    image: sourceservers/csgo:latest
+    ports:
+      - 27016:27016/tcp
+      - 27016:27016/udp
+    stdin_open: true
+    tty: true
+    entrypoint:
       - srcds_linux
     command:
-      - -game csgo -ip 0.0.0.0 -port 27015 -maxplayers 16 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+      - -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
 
   srcds-hl2mp:
     image: sourceservers/hl2mp:latest
@@ -22,7 +37,7 @@ services:
     entrypoint:
       - srcds_linux
     command:
-      - -game hl2mp -ip 0.0.0.0 -port 27015 -maxplayers 16 +map dm_lockdown
+      - -game hl2mp -port 27115 -maxplayers 16 +map dm_lockdown
 
   srcds-left4dead2:
     image: sourceservers/left4dead2:latest
@@ -34,18 +49,32 @@ services:
     entrypoint:
       - srcds_linux
     command:
-      - -game left4dead2 -ip 0.0.0.0 -port 27015 +map "c2m1_highway coop"
+      - -game left4dead2 -port 27215 +map "c2m1_highway coop"
 
-  hlds-cstrike:
+  hlds-cstrike-1:
     image: goldsourceservers/cstrike:latest
     ports:
       - 28015:28015/udp
     stdin_open: true
     tty: true
     entrypoint:
+      - /bin/bash
+      - -c
+    command:
+      - | 
+        printenv
+        ls -al
+        hlds_linux -game cstrike +port 28016 +maxplayers 10 +map de_dust2
+  hlds-cstrike-2:
+    image: goldsourceservers/cstrike:latest
+    ports:
+      - 28016:28016/udp
+    stdin_open: true
+    tty: true
+    entrypoint:
       - hlds_linux
     command:
-      - -game cstrike +ip 0.0.0.0 +port 27015 +map de_dust2 +maxplayers 16
+      - -game cstrike +port 28015 +maxplayers 10 +map de_dust2
 
   hlds-czero:
     image: goldsourceservers/czero:latest
@@ -56,7 +85,7 @@ services:
     entrypoint:
       - hlds_linux
     command:
-      - -game czero +ip 0.0.0.0 +port 27015 +map de_dust2_cz +maxplayers 16
+      - -game czero +port 28115 +maxplayers 10 +map de_dust2_cz
 
   hlds-valve:
     image: goldsourceservers/valve:latest
@@ -67,4 +96,4 @@ services:
     entrypoint:
       - hlds_linux
     command:
-      - -game valve +ip 0.0.0.0 +port 27015 +map boot_camp +maxplayers 16
+      - -game valve +port 28215 +maxplayers 16 +map boot_camp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     command:
       - |
         set -e
-        printenvs
+        printenv
         ls -al
         srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
   srcds-csgo-2:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
   srcds-hl2mp:
     image: sourceservers/hl2mp:latest
     ports:
-      - 27015:27015/tcp
-      - 27015:27015/udp
+      - 27115:27115/tcp
+      - 27115:27115/udp
     stdin_open: true
     tty: true
     entrypoint:
@@ -27,8 +27,8 @@ services:
   srcds-left4dead2:
     image: sourceservers/left4dead2:latest
     ports:
-      - 27015:27015/tcp
-      - 27015:27015/udp
+      - 27215:27215/tcp
+      - 27215:27215/udp
     stdin_open: true
     tty: true
     entrypoint:
@@ -39,7 +39,7 @@ services:
   hlds-cstrike:
     image: goldsourceservers/cstrike:latest
     ports:
-      - 27015:27015/udp
+      - 28015:28015/udp
     stdin_open: true
     tty: true
     entrypoint:
@@ -50,7 +50,7 @@ services:
   hlds-czero:
     image: goldsourceservers/czero:latest
     ports:
-      - 27015:27015/udp
+      - 28115:28115/udp
     stdin_open: true
     tty: true
     entrypoint:
@@ -61,7 +61,7 @@ services:
   hlds-valve:
     image: goldsourceservers/valve:latest
     ports:
-      - 27015:27015/udp
+      - 28215:28215/udp
     stdin_open: true
     tty: true
     entrypoint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         set -e
         printenvs
         ls -al
-        srcds_linux -game csgo -port 27016 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+        srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
   srcds-csgo-2:
     image: sourceservers/csgo:latest
     ports:
@@ -26,7 +26,7 @@ services:
     entrypoint:
       - srcds_linux
     command:
-      - -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+      - -game csgo -port 27016 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
 
   srcds-hl2mp:
     image: sourceservers/hl2mp:latest
@@ -66,7 +66,7 @@ services:
         set -e
         printenv
         ls -al
-        hlds_linux -game cstrike +port 28016 +maxplayers 10 +map de_dust2
+        hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2
   hlds-cstrike-2:
     image: goldsourceservers/cstrike:latest
     ports:
@@ -76,7 +76,7 @@ services:
     entrypoint:
       - hlds_linux
     command:
-      - -game cstrike +port 28015 +maxplayers 10 +map de_dust2
+      - -game cstrike +port 28016 +maxplayers 10 +map de_dust2
 
   hlds-czero:
     image: goldsourceservers/czero:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,70 @@
 version: '2.2'
 services:
-  # srcds
-  csgo:
+  srcds-csgo:
     image: sourceservers/csgo:latest
     ports:
-      - 27015:27015
+      - 27015:27015/tcp
+      - 27015:27015/udp
     stdin_open: true
     tty: true
     entrypoint:
       - srcds_linux
     command:
-      - -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
-  # hlds
-  cstrike:
+      - -game csgo -ip 0.0.0.0 -port 27015 -maxplayers 16 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+
+  srcds-hl2mp:
+    image: sourceservers/hl2mp:latest
+    ports:
+      - 27015:27015/tcp
+      - 27015:27015/udp
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - srcds_linux
+    command:
+      - -game hl2mp -ip 0.0.0.0 -port 27015 -maxplayers 16 +map dm_lockdown
+
+  srcds-left4dead2:
+    image: sourceservers/left4dead2:latest
+    ports:
+      - 27015:27015/tcp
+      - 27015:27015/udp
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - srcds_linux
+    command:
+      - -game left4dead2 -ip 0.0.0.0 -port 27015 +map "c2m1_highway coop"
+
+  hlds-cstrike:
     image: goldsourceservers/cstrike:latest
     ports:
-      - 27016:27016
+      - 27015:27015/udp
     stdin_open: true
     tty: true
     entrypoint:
       - hlds_linux
     command:
-      - -game cstrike +port 27016 +maxplayers 10 +map de_dust2
+      - -game cstrike +ip 0.0.0.0 +port 27015 +map de_dust2 +maxplayers 16
+
+  hlds-czero:
+    image: goldsourceservers/czero:latest
+    ports:
+      - 27015:27015/udp
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - hlds_linux
+    command:
+      - -game czero +ip 0.0.0.0 +port 27015 +map de_dust2_cz +maxplayers 16
+
+  hlds-valve:
+    image: goldsourceservers/valve:latest
+    ports:
+      - 27015:27015/udp
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - hlds_linux
+    command:
+      - -game valve +ip 0.0.0.0 +port 27015 +map boot_camp +maxplayers 16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
       - /bin/bash
       - -c
     command:
-      - | 
-        printenv
+      - |
+        set -e
+        printenvs
         ls -al
         srcds_linux -game csgo -port 27016 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
   srcds-csgo-2:
@@ -61,7 +62,8 @@ services:
       - /bin/bash
       - -c
     command:
-      - | 
+      - |
+        set -e
         printenv
         ls -al
         hlds_linux -game cstrike +port 28016 +maxplayers 10 +map de_dust2

--- a/docs/samples/docker-compose/docker-compose.bash-c.yml
+++ b/docs/samples/docker-compose/docker-compose.bash-c.yml
@@ -1,0 +1,34 @@
+version: '2.2'
+services:
+  srcds-csgo:
+    image: sourceservers/csgo:latest
+    ports:
+      - 27015:27015/tcp
+      - 27015:27015/udp
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - /bin/bash
+      - -c
+    command:
+      - |
+        set -e
+        printenv
+        ls -al
+        srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+
+  hlds-cstrike:
+    image: goldsourceservers/cstrike:latest
+    ports:
+      - 28015:28015/udp
+    stdin_open: true
+    tty: true
+    entrypoint:
+      - /bin/bash
+      - -c
+    command:
+      - |
+        set -e
+        printenv
+        ls -al
+        hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2

--- a/docs/samples/docker-compose/docker-compose.binary.yml
+++ b/docs/samples/docker-compose/docker-compose.binary.yml
@@ -1,22 +1,6 @@
 version: '2.2'
 services:
-  srcds-csgo-1:
-    image: sourceservers/csgo:latest
-    ports:
-      - 27015:27015/tcp
-      - 27015:27015/udp
-    stdin_open: true
-    tty: true
-    entrypoint:
-      - /bin/bash
-      - -c
-    command:
-      - |
-        set -e
-        printenv
-        ls -al
-        srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
-  srcds-csgo-2:
+  srcds-csgo:
     image: sourceservers/csgo:latest
     ports:
       - 27016:27016/tcp
@@ -52,22 +36,7 @@ services:
     command:
       - -game left4dead2 -port 27215 +map "c2m1_highway coop"
 
-  hlds-cstrike-1:
-    image: goldsourceservers/cstrike:latest
-    ports:
-      - 28015:28015/udp
-    stdin_open: true
-    tty: true
-    entrypoint:
-      - /bin/bash
-      - -c
-    command:
-      - |
-        set -e
-        printenv
-        ls -al
-        hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2
-  hlds-cstrike-2:
+  hlds-cstrike:
     image: goldsourceservers/cstrike:latest
     ports:
       - 28016:28016/udp

--- a/docs/samples/docker-compose/docker-compose.binary.yml
+++ b/docs/samples/docker-compose/docker-compose.binary.yml
@@ -3,14 +3,14 @@ services:
   srcds-csgo:
     image: sourceservers/csgo:latest
     ports:
-      - 27016:27016/tcp
-      - 27016:27016/udp
+      - 27015:27015/tcp
+      - 27015:27015/udp
     stdin_open: true
     tty: true
     entrypoint:
       - srcds_linux
     command:
-      - -game csgo -port 27016 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+      - -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
 
   srcds-hl2mp:
     image: sourceservers/hl2mp:latest
@@ -39,13 +39,13 @@ services:
   hlds-cstrike:
     image: goldsourceservers/cstrike:latest
     ports:
-      - 28016:28016/udp
+      - 28015:28015/udp
     stdin_open: true
     tty: true
     entrypoint:
       - hlds_linux
     command:
-      - -game cstrike +port 28016 +maxplayers 10 +map de_dust2
+      - -game cstrike +port 28015 +maxplayers 10 +map de_dust2
 
   hlds-czero:
     image: goldsourceservers/czero:latest


### PR DESCRIPTION
Adds example documentation so that users know the best practices for starting servers using `docker run` or `docker-compose`,

Also includes revision to the 'Updating' section in `README.md`.

Related: #1, #3, #22