### PR TITLE
Refactor (ci): Simplify sending of build notification on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ workflows:
     when: << pipeline.parameters.APPID >>       # Push builds can be disabled by enabling 'Only build pull requests' via project settings
     jobs:
     - build-image
-    - send-notification
 
 jobs:
   build-image:
@@ -69,27 +68,10 @@ jobs:
         no_output_timeout: 40m
         command: |
           export PIPELINE="$CIRCLE_BRANCH"
-          ./build.sh
-
-  send-notification:
-    machine:
-      image: ubuntu-2004:2022.07.1
-      docker_layer_caching: false
-    environment:
-      GAME_VERSION: << pipeline.parameters.GAME_VERSION >>
-      APPID: << pipeline.parameters.APPID >>
-      CLIENT_APPID: << pipeline.parameters.CLIENT_APPID >>
-      GAME: << pipeline.parameters.GAME >>
-      MOD: << pipeline.parameters.MOD >>
-      FIX_APPMANIFEST: << pipeline.parameters.FIX_APPMANIFEST >>
-      GAME_UPDATE_COUNT: << pipeline.parameters.GAME_UPDATE_COUNT >>
-      LATEST: << pipeline.parameters.LATEST >>
-      CACHE: << pipeline.parameters.CACHE >>
-      NO_TEST: << pipeline.parameters.NO_TEST >>
-      NO_PUSH: << pipeline.parameters.NO_PUSH >>
-    steps:
-    - checkout
+          ./build.sh && echo 'success' > build-status || echo 'failed' > build-status
     - run:
         name: Send notification
+        when: always
         command: |
+          export BUILD_STATUS=$( cat build-status )
           ./notify.circleci.sh

--- a/notify.circleci.sh
+++ b/notify.circleci.sh
@@ -1,62 +1,53 @@
 #/bin/sh
 
-# Keep checking status of my workflow's sibling job. Once it's completed, send a notification.
-SLEEP=5
-SLEPT=0
-SLEEP_THRESHOLD=7200
-while true; do
-    JOB=$( curl -s -X GET -H "Circle-Token: $CIRCLE_API_TOKEN" -H 'Accept: application/json' "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" | jq -r '.items[] | select(.name == "build-image")' )
-    date
-    echo "JOB:" $JOB
-    if [ -z "$JOB" ]; then
-        echo "No job name matching 'build-image'"
-        exit 1
-    fi
-    export JOB_STATUS=$( echo -n "$JOB" | jq -r '.status' )
-    if [ "$JOB_STATUS" == "success" ] || [ "$JOB_STATUS" == "failed" ] || [ "$JOB_STATUS" == "cancelled" ]; then
-        echo "Sending notification"
-        export JOB_NUMBER=$( echo -n "$JOB" | jq -r '.job_number' )
-        BODY=$( cat <<EOF
+# Process job variables
+BUILD_STATUS=${BUILD_STATUS:?err}
+GAME_VERSION=${GAME_VERSION:-}
+APPID=${APPID:-}
+CLIENT_APPID=${CLIENT_APPID:-}
+GAME=${GAME:-}
+MOD=${MOD:-}
+FIX_APPMANIFEST=${FIX_APPMANIFEST:-}
+GAME_UPDATE_COUNT=${GAME_UPDATE_COUNT:-}
+LATEST=${LATEST:-}
+CACHE=${CACHE:-}
+NO_TEST=${NO_TEST:-}
+NO_PUSH=${NO_PUSH:-}
+
+# Send notification
+date
+echo "Sending notification"
+BODY=$( cat <<EOF
 {
-    "build_num": "$JOB_NUMBER",
-    "username": "$CIRCLE_PROJECT_USERNAME",
-    "reponame": "$CIRCLE_PROJECT_REPONAME",
-    "branch": "$CIRCLE_BRANCH",
-    "build_parameters": {
-        "GAME_VERSION": "$GAME_VERSION",
-        "APPID": "$APPID",
-        "CLIENT_APPID": "$CLIENT_APPID",
-        "GAME": "$GAME",
-        "MOD": "$MOD",
-        "FIX_APPMANIFEST": "$FIX_APPMANIFEST",
-        "GAME_UPDATE_COUNT": "$GAME_UPDATE_COUNT",
-        "LATEST": "$LATEST",
-        "CACHE": "$CACHE",
-        "NO_TEST": "$NO_TEST",
-        "NO_PUSH": "$NO_PUSH"
-    },
-    "status": "$JOB_STATUS"
+"build_num": "$CIRCLE_BUILD_NUM",
+"username": "$CIRCLE_PROJECT_USERNAME",
+"reponame": "$CIRCLE_PROJECT_REPONAME",
+"branch": "$CIRCLE_BRANCH",
+"build_parameters": {
+    "GAME_VERSION": "$GAME_VERSION",
+    "APPID": "$APPID",
+    "CLIENT_APPID": "$CLIENT_APPID",
+    "GAME": "$GAME",
+    "MOD": "$MOD",
+    "FIX_APPMANIFEST": "$FIX_APPMANIFEST",
+    "GAME_UPDATE_COUNT": "$GAME_UPDATE_COUNT",
+    "LATEST": "$LATEST",
+    "CACHE": "$CACHE",
+    "NO_TEST": "$NO_TEST",
+    "NO_PUSH": "$NO_PUSH"
+},
+"status": "$BUILD_STATUS"
 }
 EOF
-        )
-        echo "BODY: $BODY"
-        date
-        STATUS=$( curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -H "x-circleci-webhook-secret: $X_CIRCLECI_WEBHOOK_SECRET" --data "$BODY" "$NOTIFICATION_WEBHOOK" && exit 0 || exit 1 )
-        echo "STATUS: $STATUS"
-        if [ $STATUS -eq 200 ] || [ $STATUS -eq 201 ]; then
-            echo "Notification sent"
-            exit 0
-        else
-            echo "Failed to send notification"
-            exit 1
-        fi
-    else
-        SLEPT=$(($SLEPT+$SLEEP))
-        if [ "$SLEPT" -ge "$SLEEP_THRESHOLD" ]; then
-            echo "Job has been running too long"
-            exit 1
-        fi
-        echo "Sleeping for $SLEEP seconds before checking again"
-        sleep $SLEEP
-    fi
-done
+)
+echo "BODY: $BODY"
+date
+STATUS=$( curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -H "x-circleci-webhook-secret: $X_CIRCLECI_WEBHOOK_SECRET" --data "$BODY" "$NOTIFICATION_WEBHOOK" && exit 0 || exit 1 )
+echo "STATUS: $STATUS"
+if [ $STATUS -eq 200 ] || [ $STATUS -eq 201 ]; then
+    echo "Notification sent"
+    exit 0
+else
+    echo "Failed to send notification"
+    exit 1
+fi


### PR DESCRIPTION
Notifications will be sent as a later step in the `build-image` job rather with a separate, parallel job.