### PR TITLE
Refactor (ci): Bump gitlab-ci `send-notification` job image to `alpine:3.14.8`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ build-image:
 
 send-notification:
   stage: post-build
-  image: alpine:3.8
+  image: alpine:3.14.8
   rules:
     - if: $CI_PIPELINE_SOURCE == "trigger"
     - if: $CI_PIPELINE_SOURCE == "web"


### PR DESCRIPTION
The present `alpine:3.8` image is outdated and risks failing to send notifications due to outdated `ca-certificates*` package(s).