### PR TITLE
Fix (ci): Fix shell dot source syntax

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Test
       run: |
         set -a
-        . test/build-hlds-cstrike.env
+        . ./test/build-hlds-cstrike.env
         ./build.sh
       env:
         STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
@@ -35,7 +35,7 @@ jobs:
     - name: Test
       run: |
         set -a
-        . test/update-hlds-cstrike.env
+        . ./test/update-hlds-cstrike.env
         ./build.sh
       env:
         STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
@@ -49,7 +49,7 @@ jobs:
     - name: Test
       run: |
         set -a
-        . test/build-srcds-hl2mp.env
+        . ./test/build-srcds-hl2mp.env
         ./build.sh
       env:
         STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
@@ -63,7 +63,7 @@ jobs:
     - name: Test
       run: |
         set -a
-        . test/update-srcds-hl2mp.env
+        . ./test/update-srcds-hl2mp.env
         ./build.sh
       env:
         STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}


### PR DESCRIPTION
Sourcing in shell appears to require the `. ./file` syntax. `. file` seems to work only in github workflows' bash environment.

This reverts commit 01a08da14ccdb413881f16d5aff379ae5f95d9c0.