### PR TITLE
Fix (ci): Remove use of `docker build` `--cache-from` for clean images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -129,7 +129,6 @@ if [ "$PIPELINE" = 'build' ]; then
     fi
     date
     time docker build \
-        --cache-from "$GAME_IMAGE" \
         --secret id=STEAM_USERNAME,env=STEAM_USERNAME \
         --secret id=STEAM_PASSWORD,env=STEAM_PASSWORD \
         --build-arg APPID="$APPID" \


### PR DESCRIPTION
`docker build` by default automatically already uses build cache. Specifying `--cache-from` is unnecessary and could result in the use of trailing, unwanted cache from previously failed or false success builds sharing the same docker environment.