### PR TITLE
Docs (examples): Use `+game_mode 0` for `srcds-csgo` command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ The default [work directory](build/Dockerfile#L105) for all the images is [`/ser
 ```shell
 # Counter-Strike: Global Offensive
 ## Via default entrypoint (/bin/bash -c)
-docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
-docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 0 +mapgroup mg_active +map de_dust2'
+docker run -it -p 27015:27015/tcp -p 27015:27015/udp sourceservers/csgo:latest 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 0 +mapgroup mg_active +map de_dust2'
 ## Via custom entrypoint (game binary)
-docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint srcds_linux sourceservers/csgo:latest -game csgo -port 27015 +game_type 0 +game_mode 0 +mapgroup mg_active +map de_dust2
 ## Via custom entrypoint (/bin/bash)
-docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint /bin/bash sourceservers/csgo:latest -c 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2'
+docker run -it -p 27015:27015/tcp -p 27015:27015/udp --entrypoint /bin/bash sourceservers/csgo:latest -c 'printenv && ls -al && exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 0 +mapgroup mg_active +map de_dust2'
 
 # Counter-Strike 1.6
 ## Via default entrypoint (/bin/bash -c)

--- a/docs/samples/docker-compose/docker-compose.bash-c.yml
+++ b/docs/samples/docker-compose/docker-compose.bash-c.yml
@@ -15,7 +15,7 @@ services:
         set -e
         printenv
         ls -al
-        srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+        srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 0 +mapgroup mg_active +map de_dust2
 
   hlds-cstrike:
     image: goldsourceservers/cstrike:latest

--- a/docs/samples/docker-compose/docker-compose.binary.yml
+++ b/docs/samples/docker-compose/docker-compose.binary.yml
@@ -10,7 +10,7 @@ services:
     entrypoint:
       - srcds_linux
     command:
-      - -game csgo -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+      - -game csgo -port 27015 +game_type 0 +game_mode 0 +mapgroup mg_active +map de_dust2
 
   srcds-hl2mp:
     image: sourceservers/hl2mp:latest


### PR DESCRIPTION
Using `+game_type 0 +game_mode 1` with the present game parameters and cvars results in the player spawning in a separate section of the map instead of at team base(s). With `+game_type 0 +game_mode 0`, players spawn correctly at team base(s). It's likely additional parameters or cvars are required for the game to commence correctly with `+game_mode 1`. It would also be more fail-safe to use `+game_mode 0` with `classic` `casual` being `csgo`'s most default game mode.