### PR TITLE
Fix (ci): Add label `game_version_base` to base images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -142,6 +142,7 @@ if [ "$PIPELINE" = 'build' ]; then
         --label "client_appid=$CLIENT_APPID" \
         --label "game=$GAME" \
         --label "game_version=$GAME_VERSION" \
+        --label "game_version_base=$GAME_VERSION" \
         --label 'game_update_count=0' \
         --label "game_engine=$GAME_ENGINE" \
         "$BUILD_CONTEXT"


### PR DESCRIPTION
Labels are no longer added as layers in builds with `docker buildx`. Since the label `game_version` is mutated on game image updates, a separate label `game_version_base` should be added to base images for recording of the base image game version.