### PR TITLE
Fix (ci): Retain `/root/Steam/appcache` for `hlds/*` games to not be re-downloaded entirely on `update`

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -73,8 +73,8 @@ RUN --mount=type=secret,id=STEAM_USERNAME \
             ls -al "$SERVER_DIR/steamapps"; \
         fi; \
     done; \
-    echo "[BUILD] Performing cleanup" \
-    && cd "$STEAMCMD_DIR" && rm -rf \
+    echo "[BUILD] Performing cleanup"; \
+    cd "$STEAMCMD_DIR" && rm -rf \
         linux64 \
         package \
         public \
@@ -84,9 +84,14 @@ RUN --mount=type=secret,id=STEAM_USERNAME \
         linux32/libvstdlib_s.so \
         linux32/steamclient.so \
         linux32/steamconsole.so \
-        update_hosts_cached.vdf \
-        /root/.steam \
-        /root/Steam
+        update_hosts_cached.vdf; \
+    rm -rf /root/.steam; \
+    if [ "$APPID" = 90 ]; then \
+        # Retain `/root/Steam/appcache` to prevent `steamcmd` from re-downloading `hlds` game entirely on game updates
+        rm -rf $( find /root/Steam -mindepth 1 -maxdepth 1 | grep -v '^/root/Steam/appcache' ); \
+    else \
+        rm -rf /root/Steam; \
+    fi;
 
 # Apply game fixes
 RUN echo "[BUILD] Applying game fixes"; \

--- a/update/Dockerfile
+++ b/update/Dockerfile
@@ -39,8 +39,8 @@ RUN --mount=type=secret,id=STEAM_USERNAME \
         ls -al "$SERVER_DIR/steamapps"; \
         i=$(( i+1 )); \
     done; \
-    echo "[UPDATE] Performing cleanup" \
-    && cd "$STEAMCMD_DIR" && rm -rf \
+    echo "[UPDATE] Performing cleanup"; \
+    cd "$STEAMCMD_DIR" && rm -rf \
         linux64 \
         package \
         public \
@@ -50,6 +50,11 @@ RUN --mount=type=secret,id=STEAM_USERNAME \
         linux32/libvstdlib_s.so \
         linux32/steamclient.so \
         linux32/steamconsole.so \
-        update_hosts_cached.vdf \
-        /root/.steam \
-        /root/Steam
+        update_hosts_cached.vdf; \
+    rm -rf /root/.steam; \
+    if [ "$APPID" = 90 ]; then \
+        # Retain `/root/Steam/appcache` to prevent `steamcmd` from re-downloading `hlds` game entirely on game updates
+        rm -rf $( find /root/Steam -mindepth 1 -maxdepth 1 | grep -v '^/root/Steam/appcache' ); \
+    else \
+        rm -rf /root/Steam; \
+    fi;


### PR DESCRIPTION
Do not remove `/root/Steam/appcache`. If `/root/Steam/appcache` is removed, `steamcmd` re-downloads `hlds/*` games  from scratch whenever the game is updated:

- Since `INSTALL_COUNT=1` in `update/Dockerfile`, the first time steam updates the game without `/root/Steam/appcache`, it purges all the game files. This explains the failure on master d483030a1476ace7a5efcb9d2b206c2ac0d02ee4 after #112.
- It takes `INSTALL_COUNT=2` or `INSTALL_COUNT=3` to properly `update` `hlds`. (redownload the game)
- The final incremental image grows by 1x.

