### PR TITLE
Enhancement (ci): Create artifact with base and layered size at end of `build.sh` and test `update` size

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -214,3 +214,18 @@ fi
 if [ ! "$NO_PUSH" = 'true' ]; then
     docker logout
 fi
+
+# Create build.state artifact
+echo "Creating build.state artifact"
+# Searching for 'WORKDIR /server' is a reliable way to locate the base image layers
+BASE_SIZE=0; for i in $( docker history "$REPOSITORY:latest" --format='{{.Size}} {{.CreatedAt}} {{.CreatedBy}}' --no-trunc --human=false | grep 'WORKDIR /server' -A99999 | awk '{print $1}' ); do BASE_SIZE=$(( $BASE_SIZE + $i )); done
+# Searching for 'UPDATE' is a reliable way to determine the incremental image layers
+LAYERS_SIZE=0; for i in $( docker history "$REPOSITORY:latest" --format='{{.Size}} {{.CreatedAt}} {{.CreatedBy}}' --no-trunc --human=false | grep UPDATE | awk '{print $1}' ); do LAYERS_SIZE=$(( $LAYERS_SIZE + $i )); done
+LAYERED_SIZE=$(( $BASE_SIZE + $LAYERS_SIZE ))
+cat - > build.state <<EOF
+BASE_SIZE=$BASE_SIZE
+LAYERED_SIZE=$LAYERED_SIZE
+DIFF=$LAYERS_SIZE
+EOF
+cat build.state
+ls -al build.state


### PR DESCRIPTION
As discussed in #113, there needs a test to ensure the image doesn't grow significantly during `update`.

This PR creates an artifact with `BASE_SIZE`, `LAYERED_SIZE`, and `DIFF`, which can be used in later steps such as with `notify.sh`.