### PR TITLE
Fix (ci): Use `df -h || true` in `build.sh` for non-`sudo`  environments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -109,7 +109,7 @@ whoami
 cat /etc/*release
 lscpu
 free
-df -h
+df -h || true
 pwd
 docker info
 docker version


### PR DESCRIPTION
E.g. on `alpine`, `df -h` as a regular user may fail:

```sh
$ ./build.sh
df: /var/lib/docker/overlay2/3c1454738995025818fa1c72050c4d91624479ae66c8b20b576058efafcb978f/merged: Permission denied
df: /run/docker/netns/5e6ac152cf9e: Permission denied
```