### PR TITLE
Feature (ci): Add `./build.sh --env-file` param to build from an `.env` file

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -18,17 +18,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: Test build
       run: |
-        set -a
-        . ./test/build-hlds-cstrike.env
-        ./build.sh
+        ./build.sh --env-file ./test/build-hlds-cstrike.env
       env:
         STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
         STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
     - name: Test update
       run: |
-        set -a
-        . ./test/update-hlds-cstrike.env
-        ./build.sh
+        ./build.sh --env-file ./test/update-hlds-cstrike.env
       env:
         STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
         STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
@@ -39,17 +35,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: Test build
       run: |
-        set -a
-        . ./test/build-srcds-hl2mp.env
-        ./build.sh
+        ./build.sh --env-file ./test/build-srcds-hl2mp.env
       env:
         STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
         STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
     - name: Test update
       run: |
-        set -a
-        . ./test/update-srcds-hl2mp.env
-        ./build.sh
+        ./build.sh --env-file ./test/update-srcds-hl2mp.env
       env:
         STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
         STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,24 @@
 
 #############################  End of CI variables  ##############################
 
+# Get some options
+while test $# -gt 0; do
+    case "$1" in
+        -f|--env-file)
+            shift
+            ENV_FILE=$1
+            shift
+            ;;
+    esac
+done
+
+ENV_FILE=${ENV_FILE:-.env}
+if [ -f "$ENV_FILE" ]; then
+    ENV_FILE="$( cd "$( dirname "$ENV_FILE" )" && pwd )/$( basename "$ENV_FILE" )"
+    echo "Reading env file $ENV_FILE"
+    . "$ENV_FILE"
+fi
+
 # Process user variables
 REGISTRY_USER=${REGISTRY_USER:?err}
 REGISTRY_PASSWORD=${REGISTRY_PASSWORD:?err}


### PR DESCRIPTION
This makes it eaiser to run builds against a custom `.env` file.
