### PR TITLE
Enhancement (ci): Add `DOCKER_REPOSITORY` env var and deprecate `REGISTRY_GOLDSOURCE` and `REGISTRY_SOURCE` env vars

### DIFF
--- a/test/build-hlds-cstrike.env
+++ b/test/build-hlds-cstrike.env
@@ -1,7 +1,6 @@
+DOCKER_REPOSITORY=goldsourceservers/cstrike
 REGISTRY_USER=
 REGISTRY_PASSWORD=
-REGISTRY_GOLDSOURCE=goldsourceservers
-REGISTRY_SOURCE=sourceservers
 
 PIPELINE=build
 

--- a/test/build-srcds-hl2mp.env
+++ b/test/build-srcds-hl2mp.env
@@ -1,7 +1,6 @@
+DOCKER_REPOSITORY=sourceservers/hl2mp
 REGISTRY_USER=
 REGISTRY_PASSWORD=
-REGISTRY_GOLDSOURCE=goldsourceservers
-REGISTRY_SOURCE=sourceservers
 
 PIPELINE=build
 

--- a/test/update-hlds-cstrike.env
+++ b/test/update-hlds-cstrike.env
@@ -1,7 +1,6 @@
+DOCKER_REPOSITORY=goldsourceservers/cstrike
 REGISTRY_USER=foo
 REGISTRY_PASSWORD=foo
-REGISTRY_GOLDSOURCE=goldsourceservers
-REGISTRY_SOURCE=sourceservers
 
 PIPELINE=update
 

--- a/test/update-srcds-hl2mp.env
+++ b/test/update-srcds-hl2mp.env
@@ -1,7 +1,6 @@
+DOCKER_REPOSITORY=sourceservers/hl2mp
 REGISTRY_USER=foo
 REGISTRY_PASSWORD=foo
-REGISTRY_GOLDSOURCE=goldsourceservers
-REGISTRY_SOURCE=sourceservers
 
 PIPELINE=update
 


### PR DESCRIPTION
- `REGISTRY_SOURCE` should not be mandatory for goldsource games
- `REGISTRY_GOLDSOURCE` should should not be mandatory for source games
- The user should be allowed to customize the docker repository

Hence, a new env var `DOCKER_REPOSITORY` is added to allow customization of the docker repository. The  `REGISTRY_GOLDSOURCE` and `REGISTRY_SOURCE` env vars are now deprecated but are still be supported for backward compatibility.
