### PR TITLE
Enhancement (ci): Remove use of `|| true` from `Display system info` commands in `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -184,7 +184,7 @@ whoami
 cat /etc/*release
 lscpu
 free
-df -h || true
+df -h
 pwd
 docker info
 docker version


### PR DESCRIPTION
With `set -e` only applied after the commands (as discussed in #126), changes in #115 can be reverted.