### PR TITLE
Docs (examples): Use `exec` for game binary in `docs/samples/docker-compose/docker-compose.bash-c.yml`

### DIFF
--- a/docs/samples/docker-compose/docker-compose.bash-c.yml
+++ b/docs/samples/docker-compose/docker-compose.bash-c.yml
@@ -13,7 +13,7 @@ services:
     command:
       - |
         set -e
-        game/bin/linuxsteamrt64/cs2 -dedicated -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
+        exec game/bin/linuxsteamrt64/cs2 -dedicated -port 27015 +game_type 0 +game_mode 1 +mapgroup mg_active +map de_dust2
 
   srcds-csgo:
     image: sourceservers/csgo:latest
@@ -30,7 +30,7 @@ services:
         set -e
         printenv
         ls -al
-        srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 0 +mapgroup mg_active +map de_dust2
+        exec srcds_linux -game csgo -port 27015 +game_type 0 +game_mode 0 +mapgroup mg_active +map de_dust2
 
   hlds-cstrike:
     image: goldsourceservers/cstrike:latest
@@ -46,4 +46,4 @@ services:
         set -e
         printenv
         ls -al
-        hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2
+        exec hlds_linux -game cstrike +port 28015 +maxplayers 10 +map de_dust2


### PR DESCRIPTION
Doing so ensures the binary is run as `PID 1` in any case.