### PR TITLE
Docs (examples): Use `/bin/bash` as entrypoint in `docs/samples/docker-compose/docker-compose.bash-c.yml`

### DIFF
--- a/docs/samples/docker-compose/docker-compose.bash-c.yml
+++ b/docs/samples/docker-compose/docker-compose.bash-c.yml
@@ -9,8 +9,8 @@ services:
     tty: true
     entrypoint:
       - /bin/bash
-      - -c
     command:
+      - -c
       - |
         set -e
         printenv
@@ -26,8 +26,8 @@ services:
     tty: true
     entrypoint:
       - /bin/bash
-      - -c
     command:
+      - -c
       - |
         set -e
         printenv
@@ -43,8 +43,8 @@ services:
     tty: true
     entrypoint:
       - /bin/bash
-      - -c
     command:
+      - -c
       - |
         set -e
         printenv
@@ -60,8 +60,8 @@ services:
     tty: true
     entrypoint:
       - /bin/bash
-      - -c
     command:
+      - -c
       - |
         set -e
         printenv
@@ -76,8 +76,8 @@ services:
     tty: true
     entrypoint:
       - /bin/bash
-      - -c
     command:
+      - -c
       - |
         set -e
         printenv
@@ -92,8 +92,8 @@ services:
     tty: true
     entrypoint:
       - /bin/bash
-      - -c
     command:
+      - -c
       - |
         set -e
         printenv
@@ -108,8 +108,8 @@ services:
     tty: true
     entrypoint:
       - /bin/bash
-      - -c
     command:
+      - -c
       - |
         set -e
         printenv


### PR DESCRIPTION
Doing so more closely mirrors the conventions of container entrypoints in containerized setups.