### PR TITLE
Fix (ci): Add job for the `.state` update commit to mirror latest build status

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,3 +49,22 @@ notify:
   script:
     - apk add --no-cache curl
     - ./notify.sh
+
+state:
+  stage: build
+  image: alpine:3.15
+  rules:
+    # Run on steam-* branches when .state is added or modified
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^steam-\w+-\w+$/
+      changes:
+        - .state
+  timeout: 5m
+  script:
+    - |
+        set -eu
+        . .state
+        if [ "$BUILD_STATUS" = 'success' ]; then
+            exit 0
+        else
+            exit 1
+        fi

--- a/Generate-GitBranches.ps1
+++ b/Generate-GitBranches.ps1
@@ -208,7 +208,7 @@ try {
         @"
 PIPELINE=update
 GAME_UPDATE_COUNT=$( if ($kv.Contains('GAME_UPDATE_COUNT')) { $kv['GAME_UPDATE_COUNT'] } else { $g['game_update_count'] } )
-GAME_VERSION=$( $g['game_version'] )
+GAME_VERSION=$( if ($kv.Contains('GAME_VERSION')) { $kv['GAME_VERSION'] } else { $g['game_version'] } )
 APPID=$( $g['appid'] )
 CLIENT_APPID=$( $g['client_appid'] )
 GAME=$( $g['game'] )


### PR DESCRIPTION
Fixes #152 where build badges show `branch not found`.
