### PR TITLE
Fix (ci): Run `state` job only on update `.state` commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ state:
   image: alpine:3.15
   rules:
     # Run on steam-* branches when .state is added or modified
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^steam-\w+-\w+$/
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^steam-\w+-\w+$/ && $CI_COMMIT_MESSAGE =~ /^Update .state/
       changes:
         - .state
   timeout: 5m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,11 @@ state:
   stage: build
   image: alpine:3.15
   rules:
+    # Never run when .trigger is added or modified
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^steam-\w+-\w+$/
+      changes:
+        - .trigger
+      when: never
     # Run on steam-* branches when .state is added or modified
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^steam-\w+-\w+$/
       changes:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ state:
   image: alpine:3.15
   rules:
     # Run on steam-* branches when .state is added or modified
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^steam-\w+-\w+$/ && $CI_COMMIT_MESSAGE =~ /^Update .state/
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^steam-\w+-\w+$/
       changes:
         - .state
   timeout: 5m


### PR DESCRIPTION
Fixes #181
